### PR TITLE
feat: Añadir función fakeApi con palabra del día

### DIFF
--- a/src/services/fakeApi.ts
+++ b/src/services/fakeApi.ts
@@ -1,0 +1,13 @@
+import { PalabraDelDia } from '../types/palabra';
+
+
+export const fetchPalabraDelDia = (): Promise<PalabraDelDia> => {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve({
+                palabra: 'coche',
+                definicion: 'Vehículo automóvil de cuatro ruedas utilizado para el transporte.'
+            });
+        }, 1000);
+    });
+};

--- a/src/types/palabra.ts
+++ b/src/types/palabra.ts
@@ -1,0 +1,4 @@
+export interface PalabraDelDia {
+    palabra: string;
+    definicion?: string;
+}


### PR DESCRIPTION
Se agrega la función `fetchPalabraDelDia` que simula una API devolviendo una palabra y su definición.  
También se define el tipo `PalabraDelDia` en `src/types/palabra.ts`.

Este PR integra correctamente esta feature a la rama `dev` como parte del flujo de desarrollo.
